### PR TITLE
Lazy record loading

### DIFF
--- a/tesutil/src/plugin/record.rs
+++ b/tesutil/src/plugin/record.rs
@@ -4,11 +4,32 @@ use std::str;
 use super::Field;
 use crate::TesError;
 
+/// Initialization status of a lazy-loaded record
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum RecordStatus {
+    Initialized,
+    Finalized,
+    Failed,
+}
+
 /// A record
 ///
 /// This trait is a general interface to the record types of different games.
 pub trait Record<F: Field>: IntoIterator<Item = F> + Sized {
-    fn read<T: Read>(f: T) -> Result<Self, TesError>;
+    /// Records a record from a binary stream with deferred parsing
+    ///
+    /// This method will read a record from a stream but not immediately parse its contents. This
+    /// can improve performance when reading a large number of records but only doing processing on
+    /// some of them. To finish loading the record, call its `finalize` method. Some record methods
+    /// will panic if called on a lazy-loaded record that has not been finalized. Refer to
+    /// individual method documentation for details.
+    fn read_lazy<T: Read>(f: T) -> Result<Self, TesError>;
+
+    fn read<T: Read>(f: T) -> Result<Self, TesError> {
+        let mut record = Self::read_lazy(f)?;
+        record.finalize()?;
+        Ok(record)
+    }
 
     fn name(&self) -> &[u8; 4];
 
@@ -19,6 +40,10 @@ pub trait Record<F: Field>: IntoIterator<Item = F> + Sized {
     fn display_name(&self) -> &str {
         str::from_utf8(self.name()).unwrap_or("<invalid>")
     }
+
+    fn status(&self) -> RecordStatus;
+
+    fn finalize(&mut self) -> Result<(), TesError>;
 
     // returning a boxed trait object from these methods avoids lifetimes metastasizing throughout
     // all the other related traits

--- a/tesutil/src/tes4/plugin/group.rs
+++ b/tesutil/src/tes4/plugin/group.rs
@@ -171,7 +171,7 @@ impl Group {
                     groups.push(group);
                 }
             } else {
-                let record = Tes4Record::read_with_name(&mut f, name)?;
+                let record = Tes4Record::read_lazy_with_name(&mut f, name)?;
                 records.push(Rc::new(RefCell::new(record)));
             }
             let end = f.seek(SeekFrom::Current(0))?;


### PR DESCRIPTION
Improve performance by deferring parsing of records until they're needed. This has reduced total conversion time by 80+% (average time before change: 78,408ms; after change: 11,703ms). Lazy-loaded records must be explicitly finalized before their fields can be accessed. Currently, this is handled transparently by the plugin, so API consumers should not need to worry about this if they're accessing records via plugins.

This functionality is implemented by both Tes3Record and Tes4Record, but only Tes4Plugin takes advantage of it, where avoiding unnecessarily decompressing compressed records makes a significant impact. Not all Tes3Records can be loaded lazily because we need to know their ID, which is a field. I have a branch, lazy-tes3, that implements lazy loading for record types that do not have IDs. That branch shows no discernible difference in performance despite deferring processing of 60-80% of records per plugin, so I won't be merging that at this time.