### PR TITLE
Load Morrowind and Oblivion worlds in parallel

### DIFF
--- a/tesutil/src/plugin.rs
+++ b/tesutil/src/plugin.rs
@@ -17,7 +17,7 @@ mod record;
 pub use record::*;
 
 /// Common functionality between different games' plugin implementations
-pub trait Plugin: Sized {
+pub trait Plugin: Sized + Send + Sync {
     fn load_file<P: AsRef<Path>>(path: P) -> Result<Self, TesError>;
 
     fn is_master(&self) -> bool;

--- a/tesutil/src/tes3/world.rs
+++ b/tesutil/src/tes3/world.rs
@@ -1,4 +1,4 @@
-use std::cell::Ref;
+use std::ops::Deref;
 use std::path::Path;
 
 use ini::Ini;
@@ -93,7 +93,10 @@ impl Tes3World {
     /// # Errors
     ///
     /// Fails if there is more than one record with the given ID.
-    pub fn get_record(&self, id: &str) -> Result<Option<Ref<Tes3Record>>, TesError> {
+    pub fn get_record(
+        &self,
+        id: &str,
+    ) -> Result<Option<impl Deref<Target = Tes3Record> + '_>, TesError> {
         for plugin in self.plugins.iter().rev() {
             if let Some(record) = plugin.get_record(id)? {
                 return Ok(Some(record));
@@ -110,7 +113,11 @@ impl Tes3World {
     /// # Errors
     ///
     /// Fails if there is more than one record with the given ID and type.
-    pub fn get_record_with_type(&self, id: &str, name: &[u8; 4]) -> Option<Ref<Tes3Record>> {
+    pub fn get_record_with_type(
+        &self,
+        id: &str,
+        name: &[u8; 4],
+    ) -> Option<impl Deref<Target = Tes3Record> + '_> {
         self.plugins
             .iter()
             .rev()

--- a/tesutil/src/tes4/world.rs
+++ b/tesutil/src/tes4/world.rs
@@ -1,5 +1,5 @@
-use std::cell::{Ref, RefMut};
 use std::fs;
+use std::ops::{Deref, DerefMut};
 use std::path::Path;
 
 use super::plugin::*;
@@ -91,7 +91,7 @@ impl Tes4World {
     }
 
     /// Gets a record by form ID
-    pub fn get_record(&self, search: &FindForm) -> Option<Ref<Tes4Record>> {
+    pub fn get_record(&self, search: &FindForm) -> Option<impl Deref<Target = Tes4Record> + '_> {
         let form_id = self.get_form_id(search)?;
         let index = form_id.index() as usize;
         if index == 0xff {
@@ -125,7 +125,10 @@ impl Tes4World {
     }
 
     /// Gets a record by form ID
-    pub fn get_record_mut(&self, search: &FindForm) -> Option<RefMut<Tes4Record>> {
+    pub fn get_record_mut(
+        &self,
+        search: &FindForm,
+    ) -> Option<impl Deref<Target = Tes4Record> + DerefMut<Target = Tes4Record> + '_> {
         let form_id = self.get_form_id(search)?;
         let index = form_id.index() as usize;
         if index == 0xff {


### PR DESCRIPTION
Addressing issue #14. This runs the load of the Morrowind world and the Oblivion world on two different threads. This improves performance by about 15% for me.

I also tried a version that additionally parallelized loading each file within these two processes. The difference in speed was pretty small (but not zero). This would probably make more difference with a large load order, but we don't want to just start a new thread for every file in that case like I did in my test, because that could be hundreds of threads, which is probably not ideal. For those reasons, I'm leaving this out for now. In the future, I should do some performance testing with large load orders and revisit this.

I also attempted an asynchronous version (branch async-load). I eventually gave up on this because it turned into a rewrite of every single trait and I/O operation in the codebase. It also required adding a number of additional dependencies to make things usable - async-std, async-recursion, and async-trait. I wouldn't be surprised if a fully asynchronous version was more efficient than this threaded approach, but I honestly just don't feel like doing such a large rewrite when I don't know for sure how much it would get me over this version.